### PR TITLE
Fix text extraction bug in generate_script

### DIFF
--- a/base.py
+++ b/base.py
@@ -195,7 +195,7 @@ def generate_script(chapter_document: Document, llm: ChatOpenAI, person_list: Li
     """
     prompt = PromptTemplate.from_template(GENERATE_SCRIPT_PROMPT)
     chain = prompt | llm | StrOutputParser()
-    result = chain.invoke({"text": chapter_document, "person_list": [person.name for person in person_list]})
+    result = chain.invoke({"text": chapter_document.page_content, "person_list": [person.name for person in person_list]})
     logger.info(f"{chapter_document.page_content[:10].strip()}...{chapter_document.page_content[-10:].strip()}提取脚本结果：\n{result}")
     return result
 


### PR DESCRIPTION
## Summary
- correct `generate_script` to pass document text rather than the Document object

## Testing
- `python -m py_compile base.py img.py prompt.py`


------
https://chatgpt.com/codex/tasks/task_e_683fab7e287c8332a0d4314315496cc8