### PR TITLE
Add Gradio web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ uv sync
 - `img.py`：调用 ComfyUI 根据描述生成人物或场景图片。
 - `audio.py`：调用 ComfyUI 生成对白或音乐音频。
 - `prompt.py`：存放与大模型交互的提示词模板。
+- `web_ui.py`：基于 Gradio 的图形界面，整合从文档上传到素材生成的完整流程。
 
 ## 运行方式
 
@@ -50,4 +51,14 @@ uv run base.py
 ```
 
 生成的脚本和人物信息会存放在 `outputs/` 目录下。若需要批量生成图片或音频，可分别运行 `img.py` 和 `audio.py`，或在 `base.py` 中按需调用。
+
+## 启动 Web 界面
+
+通过 `web_ui.py` 可以在浏览器中体验完整流程：
+
+```bash
+uv run web_ui.py
+```
+
+界面中可上传文本或选择示例文件，并在折叠的配置面板中填写大模型和 ComfyUI 的参数。
 

--- a/base.py
+++ b/base.py
@@ -103,7 +103,6 @@ def parse_novel_txt(path: str = "", context: str = "") -> List[Chapter]:
     else:
         with open(path, "r", encoding="utf-8") as f:
             novel_name = path.split(".")[0]
-            print(path.split("."))
             novel_text = f.read()
             soup = BeautifulSoup(novel_text, "lxml")
             if soup.find("novel") and soup.find("novel").text: # type: ignore
@@ -327,7 +326,7 @@ def extract_info_from_script(script_path: Path, person_path: Path, script: str =
     return result
 
 # 调用大模型生成人物立绘文生图的提示词然后调用文生图工具并查看生成图像进行图生图优化
-def image_generator_agent(persons: List[dict], prefix: str) -> None:
+def image_generator_agent(persons: List[dict], prefix: str, server: str = "http://127.0.0.1:8188") -> None:
     """
     该智能体可以根据人物信息生成对应的立绘
     Args:
@@ -351,7 +350,7 @@ def image_generator_agent(persons: List[dict], prefix: str) -> None:
         print(f"人物 {person['name']} 的提示词生成结果：{response.content}")
         result = extract_json(response)
         print(f"正在为人物 {person['name']} 生成立绘...")
-        img_path = run_comfy_workflow(positive=result["positive"], negative=result["negative"], prefix=prefix)
+        img_path = run_comfy_workflow(server=server, positive=result["positive"], negative=result["negative"], prefix=prefix)
         person_img_path = img_path.with_name(f"{person['name']}.png")
         img_path.rename(person_img_path)
         print(f"人物 {person['name']} 的立绘生成成功，图片路径为：{person_img_path}")
@@ -370,7 +369,7 @@ def image_generator_agent(persons: List[dict], prefix: str) -> None:
             print(f"人物 {person['name']} 标签 {label} 的提示词生成结果：{response.content}")
             result = extract_json(response)
             print(f"正在为人物 {person['name']} 标签 {label} 生成立绘...")
-            label_img_path = run_img2img_workflow(input_image=str(person_img_path.resolve()), positive=result["positive"], negative=result["negative"], prefix=prefix)
+            label_img_path = run_img2img_workflow(server=server, input_image=str(person_img_path.resolve()), positive=result["positive"], negative=result["negative"], prefix=prefix)
             person_label_img_path = img_path.with_name(f"{person['name']} {label}.png")
             label_img_path.rename(person_label_img_path)
             print(f"人物 {person['name']} 标签 {label} 的立绘生成成功，图片路径为：{person_label_img_path}")
@@ -393,7 +392,7 @@ def image_generator_agent(persons: List[dict], prefix: str) -> None:
         #     print(f"人物 {person['name']} 的立绘修改成功，图片路径为：{update_img_path}")
 
 # 调用大模型生成场景图片，采用1280x720分辨率生成背景
-def scene_generator_agent(scenes: List[str], prefix: str) -> None:
+def scene_generator_agent(scenes: List[str], prefix: str, server: str = "http://127.0.0.1:8188") -> None:
     """
     该智能体可以根据场景信息生成对应的背景图
     Args:
@@ -418,14 +417,14 @@ def scene_generator_agent(scenes: List[str], prefix: str) -> None:
         print(f"场景 {scene} 的提示词生成结果：{response.content}")
         result = extract_json(response)
         print(f"正在为场景 {scene} 生成背景图...")
-        img_path = run_comfy_workflow(positive=result["positive"], negative=result["negative"], width=910, height=512, prefix=prefix)
+        img_path = run_comfy_workflow(server=server, positive=result["positive"], negative=result["negative"], width=910, height=512, prefix=prefix)
         # 使用编号为场景名称的图片名称
         scene_img_path = img_path.with_name(f"bg {scenes.index(scene)}.png")
         img_path.rename(scene_img_path)
         print(f"场景 {scene} 的背景图生成成功，图片路径为：{scene_img_path}")
 
 # 背景音乐生成
-def music_gen(musics: List[str], prefix: str) -> None:
+def music_gen(musics: List[str], prefix: str, server: str = "http://127.0.0.1:8188") -> None:
     """从每一章节的脚本中生成适合的音乐
 
     Args:
@@ -443,7 +442,7 @@ def music_gen(musics: List[str], prefix: str) -> None:
         print(f"生成音乐提示词的LLM结果：{response}")
         result = extract_json(response)
         if result:
-            music_path = run_audio_workflow(prefix=prefix, positive=result["positive"], negative=result["negative"])
+            music_path = run_audio_workflow(server=server, prefix=prefix, positive=result["positive"], negative=result["negative"])
             result_path = music_path.with_name(f"{index}.mp3")
             music_path.rename(result_path)
             print(f"[green][b]音乐生成完成！结果保存在：{result_path}[/b][/green]")

--- a/web_ui.py
+++ b/web_ui.py
@@ -1,0 +1,120 @@
+import json
+import gradio as gr
+from pathlib import Path
+from datetime import datetime
+from typing import Iterable, Tuple
+
+from langchain_openai import ChatOpenAI
+
+from base import (
+    parse_novel_txt,
+    split_chapter,
+    generate_person,
+    generate_script,
+    extract_info_from_script,
+    image_generator_agent,
+    scene_generator_agent,
+    music_gen,
+    convert_script,
+    Person,
+)
+
+
+def pipeline(file: Path, base_url: str, api_key: str, model_name: str, comfy_server: str) -> Iterable[str]:
+    if file is None:
+        yield "请上传小说文件"
+        return
+
+    llm = ChatOpenAI(
+        base_url=base_url,
+        api_key=api_key,
+        model=model_name,
+        max_retries=2,
+        temperature=0.0,
+        max_completion_tokens=8192,
+    )
+
+    yield "开始解析文档..."
+    chapters = split_chapter(parse_novel_txt(path=file.name))
+    yield f"共识别到 {len(chapters)} 个章节"
+
+    result = ""
+    person_list: list[Person] = []
+    for chapter in chapters:
+        result += f"\n<chapter>{chapter.title}</chapter>\n"
+        for chunk in chapter.chunks:
+            person_list = generate_person(chunk, llm, person_list)
+            script = generate_script(chunk, llm, person_list, previous_script=result)
+            result += script + "\n"
+            yield script
+
+    date = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    label = Path(file.name).stem + f"_{date}"
+    base_dir = Path("outputs") / label
+    base_dir.mkdir(parents=True, exist_ok=True)
+    script_path = base_dir / "script.txt"
+    person_path = base_dir / "person.json"
+    script_path.write_text(result, encoding="utf-8")
+    person_path.write_text(
+        json.dumps([p.model_dump() for p in person_list], ensure_ascii=False, indent=4),
+        encoding="utf-8",
+    )
+    yield "脚本与人物生成完成"
+
+    info = extract_info_from_script(script_path, person_path)
+    yield "生成人物立绘..."
+    image_generator_agent(info.persons, prefix=label, server=comfy_server)
+    yield "人物立绘生成完成"
+
+    yield "生成场景图..."
+    scene_generator_agent(info.scenes, prefix=label, server=comfy_server)
+    yield "场景图生成完成"
+
+    yield "生成音乐..."
+    music_gen(info.music, prefix=label, server=comfy_server)
+    yield "音乐生成完成"
+
+    convert_script(script_path)
+    yield f"全部完成，结果保存在 outputs/{label}"
+
+
+def ui_process(file, base_url, api_key, model_name, comfy_server, history: list[Tuple[str, str]]):
+    for message in pipeline(file, base_url, api_key, model_name, comfy_server):
+        history = history + [("系统", message)]
+        yield history
+
+
+def build_interface() -> gr.Blocks:
+    examples = [str(p) for p in Path("novels").glob("*.txt")]
+
+    with gr.Blocks(title="Kaleidoscope") as demo:
+        gr.Markdown(
+            """# Kaleidoscope\n将传统小说转化为视觉小说的完整流程示例。"""
+        )
+        with gr.Accordion("配置", open=False):
+            base_url = gr.Textbox(label="LLM Base URL", value="https://dashscope.aliyuncs.com/compatible-mode/v1")
+            api_key = gr.Textbox(label="API Key", type="password")
+            model_name = gr.Textbox(label="Model Name", value="deepseek-v3")
+            comfy_server = gr.Textbox(label="ComfyUI Server", value="http://127.0.0.1:8188")
+
+        chatbot = gr.Chatbot(height=400)
+        file = gr.File(label="上传小说文本")
+        gr.Examples(examples=examples, inputs=file)
+        run_btn = gr.Button("开始转换")
+
+        run_btn.click(
+            ui_process,
+            [file, base_url, api_key, model_name, comfy_server, chatbot],
+            chatbot,
+        )
+    return demo
+
+
+def main():
+    demo = build_interface()
+    demo.queue()
+    demo.launch()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `web_ui.py` with a simple Gradio front end to run the novel pipeline
- allow specifying ComfyUI address in helper agents in `base.py`
- document the new interface in the README
- revert `requirements.txt` to its original state

## Testing
- `python -m py_compile web_ui.py base.py img.py audio.py prompt.py`


------
https://chatgpt.com/codex/tasks/task_e_6844793bf268833287f89565420153d5