### PR TITLE
Improve Gradio UI for XML input

### DIFF
--- a/web_ui.py
+++ b/web_ui.py
@@ -2,7 +2,8 @@ import json
 import gradio as gr
 from pathlib import Path
 from datetime import datetime
-from typing import Iterable, Tuple
+from typing import Iterable
+
 
 from langchain_openai import ChatOpenAI
 
@@ -19,6 +20,50 @@ from base import (
     Person,
 )
 
+LANG_CONTENT = {
+    "en": {
+        "intro": """
+            <div style='background-color:#f1f5f9;padding:1em;border-radius:8px'>
+                <h1 style='color:#6366f1;margin-top:0;'>Kaleidoscope</h1>
+                <p>A demo project that converts traditional novels into colorful visual novels.</p>
+                <ul>
+                    <li>Upload XML text split with <code>&lt;chapter&gt;</code> tags.</li>
+                    <li>The system parses chapters and generates characters, scenes and music.</li>
+                    <li>Scripts can be exported to popular visual novel engines.</li>
+                </ul>
+            </div>
+        """,
+        "upload": "Upload XML text divided by <chapter> tags",
+        "run": "Start Conversion",
+        "settings": "Settings",
+        "base_url": "LLM Base URL",
+        "api_key": "API Key",
+        "model_name": "Model Name",
+        "comfy_server": "ComfyUI Server",
+        "toggle": "切换到中文",
+    },
+    "zh": {
+        "intro": """
+            <div style='background-color:#f1f5f9;padding:1em;border-radius:8px'>
+                <h1 style='color:#6366f1;margin-top:0;'>Kaleidoscope</h1>
+                <p>这是一个将传统小说自动转化为<span style='color:#f43f5e;'>视觉小说</span>的示例项目。</p>
+                <ul>
+                    <li>上传带有 <code>&lt;chapter&gt;</code> 标签划分章节的 XML 文本。</li>
+                    <li>系统解析章节，生成角色设定、场景图和音乐。</li>
+                    <li>最终输出可在视觉小说引擎中使用的脚本。</li>
+                </ul>
+            </div>
+        """,
+        "upload": "上传使用 <chapter> 标签划分章节的 XML 文本",
+        "run": "开始转换",
+        "settings": "配置",
+        "base_url": "LLM 接口地址",
+        "api_key": "API 密钥",
+        "model_name": "模型名称",
+        "comfy_server": "ComfyUI 地址",
+        "toggle": "Switch to English",
+    },
+}
 
 def pipeline(file: Path, base_url: str, api_key: str, model_name: str, comfy_server: str) -> Iterable[str]:
     if file is None:
@@ -78,29 +123,86 @@ def pipeline(file: Path, base_url: str, api_key: str, model_name: str, comfy_ser
     yield f"全部完成，结果保存在 outputs/{label}"
 
 
-def ui_process(file, base_url, api_key, model_name, comfy_server, history: list[Tuple[str, str]]):
+def ui_process(
+    file, base_url, api_key, model_name, comfy_server, history: list[dict]
+):
+    """执行主流程并将输出追加到聊天记录中."""
+
     for message in pipeline(file, base_url, api_key, model_name, comfy_server):
-        history = history + [("系统", message)]
+        history.append({"role": "assistant", "content": message})
         yield history
+
+
+
 
 
 def build_interface() -> gr.Blocks:
     examples = [str(p) for p in Path("novels").glob("*.txt")]
 
-    with gr.Blocks(title="Kaleidoscope") as demo:
-        gr.Markdown(
-            """# Kaleidoscope\n将传统小说转化为视觉小说的完整流程示例。"""
-        )
-        with gr.Accordion("配置", open=False):
-            base_url = gr.Textbox(label="LLM Base URL", value="https://dashscope.aliyuncs.com/compatible-mode/v1")
-            api_key = gr.Textbox(label="API Key", type="password")
-            model_name = gr.Textbox(label="Model Name", value="deepseek-v3")
-            comfy_server = gr.Textbox(label="ComfyUI Server", value="http://127.0.0.1:8188")
+    theme = gr.themes.Soft(
+        primary_hue="indigo", secondary_hue="rose", neutral_hue="slate"
+    )
 
-        chatbot = gr.Chatbot(height=400)
-        file = gr.File(label="上传小说文本")
+    with gr.Blocks(title="Kaleidoscope", theme=theme) as demo:
+        lang_state = gr.State("en")
+        intro = gr.HTML(LANG_CONTENT["en"]["intro"])
+        toggle_btn = gr.Button(LANG_CONTENT["en"]["toggle"])
+
+        with gr.Accordion(LANG_CONTENT["en"]["settings"], open=False) as cfg:
+            base_url = gr.Textbox(
+                label=LANG_CONTENT["en"]["base_url"],
+                value="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            )
+            api_key = gr.Textbox(label=LANG_CONTENT["en"]["api_key"], type="password")
+            model_name = gr.Textbox(
+                label=LANG_CONTENT["en"]["model_name"], value="deepseek-v3"
+            )
+            comfy_server = gr.Textbox(
+                label=LANG_CONTENT["en"]["comfy_server"],
+                value="http://127.0.0.1:8188",
+            )
+
+        chatbot = gr.Chatbot(
+            height=400,
+            color_map=["#8b5cf6", "#10b981", "#f97316"],
+            value=[],
+        )
+        file = gr.File(label=LANG_CONTENT["en"]["upload"])
         gr.Examples(examples=examples, inputs=file)
-        run_btn = gr.Button("开始转换")
+        run_btn = gr.Button(LANG_CONTENT["en"]["run"])
+
+        def toggle_language(current_lang):
+            new_lang = "zh" if current_lang == "en" else "en"
+            content = LANG_CONTENT[new_lang]
+            return (
+                new_lang,
+                gr.update(value=content["intro"]),
+                gr.update(label=content["upload"]),
+                gr.update(value=content["run"]),
+                gr.update(label=content["base_url"]),
+                gr.update(label=content["api_key"]),
+                gr.update(label=content["model_name"]),
+                gr.update(label=content["comfy_server"]),
+                gr.update(label=content["settings"]),
+                gr.update(value=content["toggle"]),
+            )
+
+        toggle_btn.click(
+            toggle_language,
+            [lang_state],
+            [
+                lang_state,
+                intro,
+                file,
+                run_btn,
+                base_url,
+                api_key,
+                model_name,
+                comfy_server,
+                cfg,
+                toggle_btn,
+            ],
+        )
 
         run_btn.click(
             ui_process,
@@ -108,8 +210,6 @@ def build_interface() -> gr.Blocks:
             chatbot,
         )
     return demo
-
-
 def main():
     demo = build_interface()
     demo.queue()


### PR DESCRIPTION
## Summary
- switch `gr.Chatbot` to OpenAI-style message format
- add colorful theme and chatbot color map
- show project intro with `gr.HTML` for extra color
- clarify XML chapter requirement for uploads
- add Chinese/English toggle for interface text

## Testing
- `python -m py_compile web_ui.py`
- `ruff check web_ui.py`
- `ruff check .` *(fails: style issues in other files)*

------
https://chatgpt.com/codex/tasks/task_e_6844889927e8833282972ecfce979baa