### PR TITLE
Show logs in Gradio UI

### DIFF
--- a/log_config.py
+++ b/log_config.py
@@ -2,6 +2,10 @@ from loguru import logger
 import sys
 from pathlib import Path
 import os
+from typing import List
+
+# store log messages in memory so that UI can display them
+LOG_BUFFER: List[str] = []
 
 def init_logger():
     level = os.environ.get("LOG_LEVEL", "INFO").upper()
@@ -12,5 +16,10 @@ def init_logger():
     logger.remove()
     logger.add(sys.stdout, level=level, colorize=True, enqueue=True)
     logger.add(log_file, level="DEBUG", rotation="1 MB", encoding="utf-8", enqueue=True)
+    logger.add(LOG_BUFFER.append, format="{message}", level=level, enqueue=True)
+
+def get_logs(start: int = 0) -> list[str]:
+    """Return log messages starting from ``start``."""
+    return LOG_BUFFER[start:]
 
 init_logger()


### PR DESCRIPTION
## Summary
- store loguru messages in-memory so UI can read them
- display log output in Gradio interface and update it while running

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846e0495cb4833281125ca9235b4619